### PR TITLE
Detect VS Code and Cursor IDEs

### DIFF
--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -13,7 +13,39 @@ fn prints_json_with_version() {
 #[test]
 fn check_unknown_context_fails() {
     let mut cmd = Command::cargo_bin("envsense").unwrap();
-    cmd.args(["--check", "agent"])
+    cmd.args(["--check", "agent"]).assert().failure();
+}
+
+#[test]
+fn detects_vscode() {
+    let mut cmd = Command::cargo_bin("envsense").unwrap();
+    cmd.env_clear()
+        .env("TERM_PROGRAM", "vscode")
+        .env("TERM_PROGRAM_VERSION", "1.75.0")
+        .args(["--check", "facet:ide_id=vscode"])
         .assert()
-        .failure();
+        .success();
+}
+
+#[test]
+fn detects_vscode_insiders() {
+    let mut cmd = Command::cargo_bin("envsense").unwrap();
+    cmd.env_clear()
+        .env("TERM_PROGRAM", "vscode")
+        .env("TERM_PROGRAM_VERSION", "1.75.0-insider")
+        .args(["--check", "facet:ide_id=vscode-insiders"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn detects_cursor() {
+    let mut cmd = Command::cargo_bin("envsense").unwrap();
+    cmd.env_clear()
+        .env("TERM_PROGRAM", "vscode")
+        .env("TERM_PROGRAM_VERSION", "1.75.0")
+        .env("CURSOR_TRACE_ID", "xyz")
+        .args(["--check", "facet:ide_id=cursor"])
+        .assert()
+        .success();
 }


### PR DESCRIPTION
## Summary
- detect VS Code, VS Code Insiders, and Cursor IDEs using TERM_PROGRAM, TERM_PROGRAM_VERSION, and CURSOR_TRACE_ID
- integrate detection with CLI and expose via `facet:ide_id`
- add integration tests for VS Code variants and Cursor

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68a888da14508321ba758513f2114bee