### PR TITLE
Enhance check command with output and quiet mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,17 +18,17 @@ These heuristics get duplicated across dotfiles and codebases. **envsense** cent
 
 ```bash
 # Check if running inside any coding agent
-envsense --check agent && echo "Running inside a coding agent"
+envsense check agent && echo "Running inside a coding agent"
 
 # Check if specifically running in Cursor
-envsense --check facet:agent_id=cursor && echo "Cursor detected"
+envsense check facet:agent_id=cursor && echo "Cursor detected"
 
 # Check if running in VS Code or VS Code Insiders
-envsense --check facet:ide_id=vscode && echo "VS Code"
-envsense --check facet:ide_id=vscode-insiders && echo "VS Code Insiders"
+envsense check facet:ide_id=vscode && echo "VS Code"
+envsense check facet:ide_id=vscode-insiders && echo "VS Code Insiders"
 
 # Combine checks in scripts
-if envsense --check facet:ide_id=cursor; then
+if envsense check -q facet:ide_id=cursor; then
   export PAGER=cat
 fi
 ```
@@ -105,13 +105,13 @@ Example JSON output:
 
 ```bash
 # Context: any CI
-envsense --check ci && echo "In CI"
+envsense check ci && echo "In CI"
 
 # Facet: specifically GitHub Actions
-envsense --check facet:ci_id=github && echo "In GitHub Actions"
+envsense check facet:ci_id=github && echo "In GitHub Actions"
 
 # Trait: non-interactive
-if ! envsense --check trait:is_interactive; then
+if ! envsense check trait:is_interactive; then
   echo "Running non-interactive"
 fi
 ```

--- a/src/check.rs
+++ b/src/check.rs
@@ -1,10 +1,16 @@
 use thiserror::Error;
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum Check {
     Context(String),
     Facet { key: String, value: String },
     Trait { key: String },
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct ParsedCheck {
+    pub check: Check,
+    pub negated: bool,
 }
 
 #[derive(Debug, Error, PartialEq, Eq)]
@@ -40,6 +46,25 @@ pub fn parse(input: &str) -> Result<Check, ParseError> {
     Ok(Check::Context(input.to_string()))
 }
 
+pub fn parse_predicate(input: &str) -> Result<ParsedCheck, ParseError> {
+    let negated = input.starts_with('!');
+    let expr = if negated { &input[1..] } else { input };
+    let check = parse(expr)?;
+    Ok(ParsedCheck { check, negated })
+}
+
+pub const CONTEXTS: &[&str] = &["agent", "ide", "ci", "container", "remote"];
+pub const FACETS: &[&str] = &["agent_id", "ide_id", "ci_id", "container_id"];
+pub const TRAITS: &[&str] = &[
+    "is_interactive",
+    "is_tty_stdin",
+    "is_tty_stdout",
+    "is_tty_stderr",
+    "is_piped_stdin",
+    "is_piped_stdout",
+    "supports_hyperlinks",
+];
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -73,5 +98,12 @@ mod tests {
     #[test]
     fn parse_invalid() {
         assert!(parse("facet:").is_err());
+    }
+
+    #[test]
+    fn parse_not() {
+        let pc = parse_predicate("!ci").unwrap();
+        assert!(pc.negated);
+        assert_eq!(pc.check, Check::Context("ci".into()));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,14 @@
-use clap::Parser;
-use envsense::check::{self, Check};
-use envsense::schema::EnvSense;
+use clap::{Args, Parser, Subcommand, ValueEnum};
+use envsense::check::{self, CONTEXTS, FACETS, ParsedCheck, TRAITS};
+use envsense::schema::{EnvSense, Evidence};
+use std::collections::BTreeMap;
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
 struct Cli {
-    /// Evaluate a single check expression against the environment
-    #[arg(long)]
-    check: Option<String>,
+    /// Evaluate check expressions (compatibility flag)
+    #[arg(long, value_name = "PREDICATE", num_args = 1.., hide = true)]
+    check: Vec<String>,
 
     /// Output JSON (compact)
     #[arg(long)]
@@ -21,61 +22,325 @@ struct Cli {
     #[arg(long)]
     only: Option<String>,
 
-    /// When used with --check, also print the environment
+    /// When used with --check, also explain results
     #[arg(long)]
     explain: bool,
+
+    #[command(subcommand)]
+    command: Option<Commands>,
 }
 
-fn evaluate(env: &EnvSense, check: Check) -> bool {
-    match check {
-        Check::Context(ctx) => match ctx.as_str() {
-            "agent" => env.contexts.agent,
-            "ide" => env.contexts.ide,
-            "ci" => env.contexts.ci,
-            "container" => env.contexts.container,
-            "remote" => env.contexts.remote,
-            _ => false,
-        },
-        Check::Facet { key, value } => match key.as_str() {
-            "agent_id" => env.facets.agent_id.as_deref() == Some(value.as_str()),
-            "ide_id" => env.facets.ide_id.as_deref() == Some(value.as_str()),
-            "ci_id" => env.facets.ci_id.as_deref() == Some(value.as_str()),
-            "container_id" => env.facets.container_id.as_deref() == Some(value.as_str()),
-            _ => false,
-        },
-        Check::Trait { key } => match key.as_str() {
-            "is_interactive" => env.traits.is_interactive,
-            "is_tty_stdin" => env.traits.is_tty_stdin,
-            "is_tty_stdout" => env.traits.is_tty_stdout,
-            "is_tty_stderr" => env.traits.is_tty_stderr,
-            "is_piped_stdin" => env.traits.is_piped_stdin,
-            "is_piped_stdout" => env.traits.is_piped_stdout,
-            "supports_hyperlinks" => env.traits.supports_hyperlinks,
-            _ => false,
-        },
+#[derive(Subcommand)]
+enum Commands {
+    /// Evaluate predicates against the environment
+    Check(CheckCmd),
+}
+
+#[derive(Args, Clone)]
+struct CheckCmd {
+    #[arg(value_name = "PREDICATE", num_args = 1..)]
+    predicates: Vec<String>,
+
+    /// Succeed if any predicate matches (default: all must match)
+    #[arg(long, action = clap::ArgAction::SetTrue, conflicts_with = "all")]
+    any: bool,
+
+    /// Require all predicates to match (default)
+    #[arg(long, action = clap::ArgAction::SetTrue, conflicts_with = "any")]
+    all: bool,
+
+    /// Suppress output
+    #[arg(short, long, alias = "silent", action = clap::ArgAction::SetTrue)]
+    quiet: bool,
+
+    /// Output format
+    #[arg(long, value_enum, default_value_t = Format::Plain)]
+    format: Format,
+
+    /// Explain reasoning
+    #[arg(long)]
+    explain: bool,
+
+    /// List known predicates
+    #[arg(long = "list-checks", action = clap::ArgAction::SetTrue)]
+    list_checks: bool,
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, ValueEnum)]
+enum Format {
+    Plain,
+    Pretty,
+    Json,
+}
+
+#[derive(serde::Serialize)]
+struct JsonCheck {
+    predicate: String,
+    result: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    signals: Option<BTreeMap<String, String>>,
+}
+
+fn evaluate(
+    env: &EnvSense,
+    parsed: ParsedCheck,
+) -> (bool, Option<String>, Option<BTreeMap<String, String>>) {
+    let (mut result, reason, signals) = match parsed.check {
+        check::Check::Context(ctx) => {
+            let value = match ctx.as_str() {
+                "agent" => env.contexts.agent,
+                "ide" => env.contexts.ide,
+                "ci" => env.contexts.ci,
+                "container" => env.contexts.container,
+                "remote" => env.contexts.remote,
+                _ => false,
+            };
+            let evidence = find_evidence(env, &ctx);
+            (
+                value,
+                evidence_to_reason(&evidence),
+                evidence_to_signals(evidence),
+            )
+        }
+        check::Check::Facet { key, value } => {
+            let ok = match key.as_str() {
+                "agent_id" => env.facets.agent_id.as_deref() == Some(value.as_str()),
+                "ide_id" => env.facets.ide_id.as_deref() == Some(value.as_str()),
+                "ci_id" => env.facets.ci_id.as_deref() == Some(value.as_str()),
+                "container_id" => env.facets.container_id.as_deref() == Some(value.as_str()),
+                _ => false,
+            };
+            let evidence = find_evidence(env, &key);
+            (
+                ok,
+                evidence_to_reason(&evidence),
+                evidence_to_signals(evidence),
+            )
+        }
+        check::Check::Trait { key } => {
+            let ok = match key.as_str() {
+                "is_interactive" => env.traits.is_interactive,
+                "is_tty_stdin" => env.traits.is_tty_stdin,
+                "is_tty_stdout" => env.traits.is_tty_stdout,
+                "is_tty_stderr" => env.traits.is_tty_stderr,
+                "is_piped_stdin" => env.traits.is_piped_stdin,
+                "is_piped_stdout" => env.traits.is_piped_stdout,
+                "supports_hyperlinks" => env.traits.supports_hyperlinks,
+                _ => false,
+            };
+            let evidence = find_evidence(env, &key);
+            (
+                ok,
+                evidence_to_reason(&evidence),
+                evidence_to_signals(evidence),
+            )
+        }
+    };
+    if parsed.negated {
+        result = !result;
+    }
+    (result, reason, signals)
+}
+
+fn find_evidence<'a>(env: &'a EnvSense, key: &str) -> Option<&'a Evidence> {
+    env.evidence
+        .iter()
+        .find(|e| e.supports.iter().any(|s| s == key))
+}
+
+fn evidence_to_reason(e: &Option<&Evidence>) -> Option<String> {
+    e.map(|ev| {
+        if let Some(val) = &ev.value {
+            format!("{}={}", ev.key, val)
+        } else {
+            ev.key.clone()
+        }
+    })
+}
+
+fn evidence_to_signals(e: Option<&Evidence>) -> Option<BTreeMap<String, String>> {
+    e.map(|ev| {
+        let mut map = BTreeMap::new();
+        map.insert(ev.key.clone(), ev.value.clone().unwrap_or_default());
+        map
+    })
+}
+
+fn run_check(args: &CheckCmd) -> i32 {
+    if args.list_checks {
+        list_checks();
+        return 0;
+    }
+    let env = EnvSense::default();
+    let mode_any = args.any;
+    let mut results = Vec::new();
+    for pred in &args.predicates {
+        let parsed = match check::parse_predicate(pred) {
+            Ok(p) => p,
+            Err(_) => {
+                eprintln!("invalid check expression");
+                return 2;
+            }
+        };
+        let (res, reason, signals) = evaluate(&env, parsed);
+        if args.quiet {
+            if mode_any && res {
+                return 0;
+            }
+            if !mode_any && !res {
+                return 1;
+            }
+        } else {
+            results.push(JsonCheck {
+                predicate: pred.clone(),
+                result: res,
+                reason,
+                signals,
+            });
+        }
+    }
+
+    let overall = if mode_any {
+        results.iter().any(|r| r.result)
+    } else {
+        results.iter().all(|r| r.result)
+    };
+
+    if !args.quiet {
+        output_results(&results, overall, mode_any, args.format, args.explain);
+    }
+
+    if overall { 0 } else { 1 }
+}
+
+fn output_results(
+    results: &[JsonCheck],
+    overall: bool,
+    mode_any: bool,
+    format: Format,
+    explain: bool,
+) {
+    match format {
+        Format::Plain => {
+            if results.len() == 1 {
+                let r = &results[0];
+                if let Some(reason) = r.reason.as_ref().filter(|_| explain) {
+                    println!("{}  # reason: {}", r.result, reason);
+                } else {
+                    println!("{}", r.result);
+                }
+            } else {
+                println!("overall={}", overall);
+                for r in results {
+                    if let Some(reason) = r.reason.as_ref().filter(|_| explain) {
+                        println!("{}={}  # reason: {}", r.predicate, r.result, reason);
+                    } else {
+                        println!("{}={}", r.predicate, r.result);
+                    }
+                }
+            }
+        }
+        Format::Pretty => {
+            if results.len() == 1 {
+                let r = &results[0];
+                let mark = if r.result { '✓' } else { '✗' };
+                if let Some(reason) = r.reason.as_ref().filter(|_| explain) {
+                    println!("{} {} ({})", mark, r.predicate, reason);
+                } else {
+                    println!("{} {}", mark, r.predicate);
+                }
+            } else {
+                for r in results {
+                    let mark = if r.result { '✓' } else { '✗' };
+                    if let Some(reason) = r.reason.as_ref().filter(|_| explain) {
+                        println!("{} {} ({})", mark, r.predicate, reason);
+                    } else {
+                        println!("{} {}", mark, r.predicate);
+                    }
+                }
+                let mark = if overall { '✓' } else { '✗' };
+                let mode = if mode_any { "any" } else { "all" };
+                println!("overall: {} ({})", mark, mode);
+            }
+        }
+        Format::Json => {
+            #[derive(serde::Serialize)]
+            struct JsonOutput<'a> {
+                overall: bool,
+                mode: &'a str,
+                checks: &'a [JsonCheck],
+            }
+            let out = JsonOutput {
+                overall,
+                mode: if mode_any { "any" } else { "all" },
+                checks: results,
+            };
+            if explain {
+                println!("{}", serde_json::to_string_pretty(&out).unwrap());
+            } else {
+                println!("{}", serde_json::to_string(&out).unwrap());
+            }
+        }
+    }
+}
+
+fn list_checks() {
+    println!("contexts:");
+    for c in CONTEXTS {
+        println!("  {}", c);
+    }
+    println!("facets:");
+    for f in FACETS {
+        println!("  {}", f);
+    }
+    println!("traits:");
+    for t in TRAITS {
+        println!("  {}", t);
+    }
+}
+
+fn output_env(env: &EnvSense, pretty: bool) {
+    if pretty {
+        println!("{}", serde_json::to_string_pretty(env).unwrap());
+    } else {
+        println!("{}", serde_json::to_string(env).unwrap());
+    }
+}
+
+fn output_json<T: serde::Serialize>(value: &T, pretty: bool) {
+    if pretty {
+        println!("{}", serde_json::to_string_pretty(value).unwrap());
+    } else {
+        println!("{}", serde_json::to_string(value).unwrap());
     }
 }
 
 fn main() {
     let cli = Cli::parse();
-    let env = EnvSense::default();
-
-    if let Some(expr) = cli.check.as_deref() {
-        match check::parse(expr) {
-            Ok(parsed) => {
-                let ok = evaluate(&env, parsed);
-                if cli.explain {
-                    output_env(&env, cli.pretty);
-                }
-                std::process::exit(if ok { 0 } else { 1 });
-            }
-            Err(_) => {
-                eprintln!("invalid check expression");
-                std::process::exit(2);
-            }
-        }
+    if let Some(cmd) = &cli.command {
+        let code = match cmd {
+            Commands::Check(args) => run_check(args),
+        };
+        std::process::exit(code);
     }
 
+    if !cli.check.is_empty() {
+        let args = CheckCmd {
+            predicates: cli.check.clone(),
+            any: false,
+            all: false,
+            quiet: false,
+            format: Format::Plain,
+            explain: cli.explain,
+            list_checks: false,
+        };
+        let code = run_check(&args);
+        std::process::exit(code);
+    }
+
+    let env = EnvSense::default();
     if cli.json || cli.pretty || cli.only.is_some() || cli.explain {
         if let Some(section) = cli.only.as_deref() {
             match section {
@@ -93,20 +358,4 @@ fn main() {
 
     // Default behavior: print compact JSON
     output_env(&env, false);
-}
-
-fn output_env(env: &EnvSense, pretty: bool) {
-    if pretty {
-        println!("{}", serde_json::to_string_pretty(env).unwrap());
-    } else {
-        println!("{}", serde_json::to_string(env).unwrap());
-    }
-}
-
-fn output_json<T: serde::Serialize>(value: &T, pretty: bool) {
-    if pretty {
-        println!("{}", serde_json::to_string_pretty(value).unwrap());
-    } else {
-        println!("{}", serde_json::to_string(value).unwrap());
-    }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -13,7 +13,10 @@ fn prints_json_with_version() {
 #[test]
 fn check_unknown_context_fails() {
     let mut cmd = Command::cargo_bin("envsense").unwrap();
-    cmd.args(["--check", "agent"]).assert().failure();
+    cmd.args(["check", "agent"])
+        .assert()
+        .failure()
+        .stdout("false\n");
 }
 
 #[test]
@@ -22,9 +25,10 @@ fn detects_vscode() {
     cmd.env_clear()
         .env("TERM_PROGRAM", "vscode")
         .env("TERM_PROGRAM_VERSION", "1.75.0")
-        .args(["--check", "facet:ide_id=vscode"])
+        .args(["check", "facet:ide_id=vscode"])
         .assert()
-        .success();
+        .success()
+        .stdout("true\n");
 }
 
 #[test]
@@ -33,9 +37,10 @@ fn detects_vscode_insiders() {
     cmd.env_clear()
         .env("TERM_PROGRAM", "vscode")
         .env("TERM_PROGRAM_VERSION", "1.75.0-insider")
-        .args(["--check", "facet:ide_id=vscode-insiders"])
+        .args(["check", "facet:ide_id=vscode-insiders"])
         .assert()
-        .success();
+        .success()
+        .stdout("true\n");
 }
 
 #[test]
@@ -45,7 +50,17 @@ fn detects_cursor() {
         .env("TERM_PROGRAM", "vscode")
         .env("TERM_PROGRAM_VERSION", "1.75.0")
         .env("CURSOR_TRACE_ID", "xyz")
-        .args(["--check", "facet:ide_id=cursor"])
+        .args(["check", "facet:ide_id=cursor"])
         .assert()
-        .success();
+        .success()
+        .stdout("true\n");
+}
+
+#[test]
+fn quiet_flag_suppresses_output() {
+    let mut cmd = Command::cargo_bin("envsense").unwrap();
+    cmd.args(["check", "-q", "agent"])
+        .assert()
+        .failure()
+        .stdout(predicates::str::is_empty());
 }


### PR DESCRIPTION
## Summary
- Add dedicated `check` subcommand with plain/pretty/json output
- Support `-q/--quiet`, `--any/--all`, and `--format` options
- Expose helper to parse `!predicate` negation and list known checks

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a88b8294c083219ee31393992b34d4