### PR TITLE
chore: document check predicates

### DIFF
--- a/src/check.rs
+++ b/src/check.rs
@@ -22,14 +22,13 @@ pub enum ParseError {
 pub fn parse(input: &str) -> Result<Check, ParseError> {
     if let Some(rest) = input.strip_prefix("facet:") {
         let mut parts = rest.splitn(2, '=');
-        if let (Some(key), Some(value)) = (parts.next(), parts.next()) {
-            if !key.is_empty() && !value.is_empty() {
+        if let (Some(key), Some(value)) = (parts.next(), parts.next())
+            && !key.is_empty() && !value.is_empty() {
                 return Ok(Check::Facet {
                     key: key.to_string(),
                     value: value.to_string(),
                 });
             }
-        }
         return Err(ParseError::Invalid);
     }
     if let Some(rest) = input.strip_prefix("trait:") {

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,34 @@ use envsense::schema::{EnvSense, Evidence};
 use serde_json::{Map, Value, json};
 use std::collections::BTreeMap;
 use std::io::{IsTerminal, stdout};
+use std::sync::OnceLock;
+
+fn check_predicate_long_help() -> &'static str {
+    static HELP: OnceLock<String> = OnceLock::new();
+    HELP.get_or_init(|| {
+        let mut s = String::from("Predicates to evaluate\n\n");
+        s.push_str("Contexts:\n");
+        for c in CONTEXTS {
+            s.push_str("    ");
+            s.push_str(c);
+            s.push('\n');
+        }
+        s.push_str("Facets:\n");
+        for f in FACETS {
+            s.push_str("    facet:");
+            s.push_str(f);
+            s.push_str("=<VALUE>\n");
+        }
+        s.push_str("Traits:\n");
+        for t in TRAITS {
+            s.push_str("    trait:");
+            s.push_str(t);
+            s.push('\n');
+        }
+        s
+    })
+    .as_str()
+}
 
 #[derive(Parser)]
 #[command(
@@ -46,7 +74,12 @@ struct InfoArgs {
 
 #[derive(Args, Clone)]
 struct CheckCmd {
-    #[arg(value_name = "PREDICATE", num_args = 1..)]
+    #[arg(
+        value_name = "PREDICATE",
+        num_args = 1..,
+        help = "Predicates to evaluate",
+        long_help = check_predicate_long_help()
+    )]
     predicates: Vec<String>,
 
     /// Succeed if any predicate matches (default: all must match)

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -94,8 +94,8 @@ pub const SCHEMA_VERSION: &str = "0.1.0";
 
 impl EnvSense {
     fn detect_ide(&mut self) {
-        if let Ok(term_program) = std::env::var("TERM_PROGRAM") {
-            if term_program == "vscode" {
+        if let Ok(term_program) = std::env::var("TERM_PROGRAM")
+            && term_program == "vscode" {
                 self.contexts.ide = true;
                 self.evidence.push(Evidence {
                     signal: Signal::Env,
@@ -130,7 +130,6 @@ impl EnvSense {
                     });
                 }
             }
-        }
     }
 
     pub fn detect() -> Self {


### PR DESCRIPTION
## Summary
- show supported contexts, facets, and traits in `check --help`
- list each predicate on its own line for readability
- generate predicate help text dynamically from known checks
- indent each predicate under its heading for clarity

## Testing
- `cargo test`
- `cargo run --quiet -- check --help`


------
https://chatgpt.com/codex/tasks/task_e_68a8a25c262883219f03e5e0c51d4c5d