### PR TITLE
Add JSON snapshot tests for common environments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,6 +178,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "dashmap"
 version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -215,6 +227,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
 name = "envmnt"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -233,6 +251,7 @@ dependencies = [
  "ci_info",
  "clap",
  "colored",
+ "insta",
  "is-terminal",
  "predicates",
  "schemars",
@@ -372,6 +391,18 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "insta"
+version = "1.43.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "154934ea70c58054b556dd430b99a98c2a7ff5309ac9891597e339b5c28f4371"
+dependencies = [
+ "console",
+ "once_cell",
+ "serde",
+ "similar",
 ]
 
 [[package]]
@@ -688,6 +719,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ supports-hyperlinks = "3"
 ci_info = "0.14"
 
 [dev-dependencies]
+insta = { version = "1", features = ["json"] }
 assert_cmd = "2"
 predicates = "3"
 serial_test = "2"

--- a/tests/info_snapshots.rs
+++ b/tests/info_snapshots.rs
@@ -3,6 +3,14 @@ use assert_cmd::cargo::cargo_bin;
 use insta::assert_json_snapshot;
 use serde_json::Value;
 
+fn parse_json(bytes: &[u8]) -> Value {
+    let start = bytes
+        .iter()
+        .position(|&b| b == b'{')
+        .expect("json start not found");
+    serde_json::from_slice(&bytes[start..]).expect("invalid json")
+}
+
 fn run_info_json(envs: &[(&str, &str)]) -> Value {
     let mut cmd = Command::cargo_bin("envsense").unwrap();
     cmd.env_clear();
@@ -12,7 +20,7 @@ fn run_info_json(envs: &[(&str, &str)]) -> Value {
     }
     let output = cmd.output().expect("failed to run envsense");
     assert!(output.status.success());
-    serde_json::from_slice(&output.stdout).expect("invalid json")
+    parse_json(&output.stdout)
 }
 
 #[cfg(target_os = "macos")]
@@ -30,7 +38,7 @@ fn run_info_json_tty(envs: &[(&str, &str)]) -> Value {
     }
     let output = cmd.output().expect("failed to run script");
     assert!(output.status.success());
-    serde_json::from_slice(&output.stdout).expect("invalid json")
+    parse_json(&output.stdout)
 }
 
 #[cfg(not(target_os = "macos"))]
@@ -46,7 +54,7 @@ fn run_info_json_tty(envs: &[(&str, &str)]) -> Value {
     }
     let output = cmd.output().expect("failed to run script");
     assert!(output.status.success());
-    serde_json::from_slice(&output.stdout).expect("invalid json")
+    parse_json(&output.stdout)
 }
 
 #[test]

--- a/tests/info_snapshots.rs
+++ b/tests/info_snapshots.rs
@@ -1,0 +1,132 @@
+use assert_cmd::Command;
+use assert_cmd::cargo::cargo_bin;
+use insta::assert_json_snapshot;
+use serde_json::Value;
+
+fn run_info_json(envs: &[(&str, &str)]) -> Value {
+    let mut cmd = Command::cargo_bin("envsense").unwrap();
+    cmd.env_clear();
+    cmd.args(["info", "--json"]);
+    for (k, v) in envs {
+        cmd.env(k, v);
+    }
+    let output = cmd.output().expect("failed to run envsense");
+    assert!(output.status.success());
+    serde_json::from_slice(&output.stdout).expect("invalid json")
+}
+
+#[cfg(target_os = "macos")]
+fn run_info_json_tty(envs: &[(&str, &str)]) -> Value {
+    let bin = cargo_bin("envsense");
+    let mut cmd = Command::new("script");
+    cmd.arg("-q")
+        .arg("/dev/null")
+        .arg(bin)
+        .arg("info")
+        .arg("--json");
+    cmd.env_clear();
+    for (k, v) in envs {
+        cmd.env(k, v);
+    }
+    let output = cmd.output().expect("failed to run script");
+    assert!(output.status.success());
+    serde_json::from_slice(&output.stdout).expect("invalid json")
+}
+
+#[cfg(not(target_os = "macos"))]
+fn run_info_json_tty(envs: &[(&str, &str)]) -> Value {
+    let bin = cargo_bin("envsense");
+    let mut cmd = Command::new("script");
+    cmd.arg("-qec")
+        .arg(format!("{} info --json", bin.display()))
+        .arg("/dev/null");
+    cmd.env_clear();
+    for (k, v) in envs {
+        cmd.env(k, v);
+    }
+    let output = cmd.output().expect("failed to run script");
+    assert!(output.status.success());
+    serde_json::from_slice(&output.stdout).expect("invalid json")
+}
+
+#[test]
+fn snapshot_vscode() {
+    let json = run_info_json(&[
+        ("TERM_PROGRAM", "vscode"),
+        ("TERM_PROGRAM_VERSION", "1.75.0"),
+    ]);
+    assert_json_snapshot!("vscode", json);
+}
+
+#[test]
+fn snapshot_vscode_insiders() {
+    let json = run_info_json(&[
+        ("TERM_PROGRAM", "vscode"),
+        ("TERM_PROGRAM_VERSION", "1.75.0-insider"),
+    ]);
+    assert_json_snapshot!("vscode_insiders", json);
+}
+
+#[test]
+fn snapshot_cursor() {
+    let json = run_info_json(&[
+        ("TERM_PROGRAM", "vscode"),
+        ("TERM_PROGRAM_VERSION", "1.75.0"),
+        ("CURSOR_TRACE_ID", "xyz"),
+    ]);
+    assert_json_snapshot!("cursor", json);
+}
+
+#[test]
+fn snapshot_github_actions() {
+    let json = run_info_json(&[("GITHUB_ACTIONS", "1")]);
+    assert_json_snapshot!("github_actions", json);
+}
+
+#[test]
+fn snapshot_gitlab_ci() {
+    let json = run_info_json(&[("GITLAB_CI", "1")]);
+    assert_json_snapshot!("gitlab_ci", json);
+}
+
+#[test]
+fn snapshot_tmux() {
+    let json = run_info_json_tty(&[("TERM", "screen-256color"), ("TMUX", "1")]);
+    assert_json_snapshot!("tmux", json);
+}
+
+#[test]
+fn snapshot_plain_tty() {
+    let json = run_info_json_tty(&[("TERM", "xterm-256color")]);
+    assert_json_snapshot!("plain_tty", json);
+}
+
+#[test]
+fn snapshot_piped_io() {
+    let json = run_info_json(&[]);
+    assert_json_snapshot!("piped_io", json);
+}
+
+#[test]
+fn snapshot_shell_bash() {
+    let json = run_info_json(&[("SHELL", "/bin/bash")]);
+    assert_json_snapshot!("shell_bash", json);
+}
+
+#[test]
+fn snapshot_shell_zsh() {
+    let json = run_info_json(&[("SHELL", "/bin/zsh")]);
+    assert_json_snapshot!("shell_zsh", json);
+}
+
+#[test]
+fn snapshot_os_linux() {
+    let json = run_info_json(&[("OSTYPE", "linux")]);
+    assert_json_snapshot!("os_linux", json);
+}
+
+#[test]
+fn snapshot_os_macos() {
+    let json = run_info_json(&[("OSTYPE", "darwin")]);
+    assert_json_snapshot!("os_macos", json);
+}

--- a/tests/snapshots/info_snapshots__cursor.snap
+++ b/tests/snapshots/info_snapshots__cursor.snap
@@ -1,0 +1,30 @@
+---
+source: tests/info_snapshots.rs
+expression: json
+---
+{
+  "contexts": [
+    "ide"
+  ],
+  "facets": {
+    "ci": {
+      "is_ci": false
+    },
+    "ide_id": "cursor"
+  },
+  "meta": {
+    "rules_version": "",
+    "schema_version": "0.1.0"
+  },
+  "traits": {
+    "color_level": "none",
+    "is_ci": false,
+    "is_interactive": false,
+    "is_piped_stdin": true,
+    "is_piped_stdout": true,
+    "is_tty_stderr": false,
+    "is_tty_stdin": false,
+    "is_tty_stdout": false,
+    "supports_hyperlinks": false
+  }
+}

--- a/tests/snapshots/info_snapshots__github_actions.snap
+++ b/tests/snapshots/info_snapshots__github_actions.snap
@@ -1,0 +1,36 @@
+---
+source: tests/info_snapshots.rs
+expression: json
+---
+{
+  "contexts": [
+    "ci"
+  ],
+  "facets": {
+    "ci": {
+      "is_ci": true,
+      "name": "GitHub Actions",
+      "pr": false,
+      "vendor": "github_actions"
+    },
+    "ci_id": "github_actions"
+  },
+  "meta": {
+    "rules_version": "",
+    "schema_version": "0.1.0"
+  },
+  "traits": {
+    "ci_name": "GitHub Actions",
+    "ci_pr": false,
+    "ci_vendor": "github_actions",
+    "color_level": "none",
+    "is_ci": true,
+    "is_interactive": false,
+    "is_piped_stdin": true,
+    "is_piped_stdout": true,
+    "is_tty_stderr": false,
+    "is_tty_stdin": false,
+    "is_tty_stdout": false,
+    "supports_hyperlinks": false
+  }
+}

--- a/tests/snapshots/info_snapshots__gitlab_ci.snap
+++ b/tests/snapshots/info_snapshots__gitlab_ci.snap
@@ -1,0 +1,36 @@
+---
+source: tests/info_snapshots.rs
+expression: json
+---
+{
+  "contexts": [
+    "ci"
+  ],
+  "facets": {
+    "ci": {
+      "is_ci": true,
+      "name": "GitLab CI",
+      "pr": false,
+      "vendor": "gitlab_ci"
+    },
+    "ci_id": "gitlab_ci"
+  },
+  "meta": {
+    "rules_version": "",
+    "schema_version": "0.1.0"
+  },
+  "traits": {
+    "ci_name": "GitLab CI",
+    "ci_pr": false,
+    "ci_vendor": "gitlab_ci",
+    "color_level": "none",
+    "is_ci": true,
+    "is_interactive": false,
+    "is_piped_stdin": true,
+    "is_piped_stdout": true,
+    "is_tty_stderr": false,
+    "is_tty_stdin": false,
+    "is_tty_stdout": false,
+    "supports_hyperlinks": false
+  }
+}

--- a/tests/snapshots/info_snapshots__os_linux.snap
+++ b/tests/snapshots/info_snapshots__os_linux.snap
@@ -1,0 +1,27 @@
+---
+source: tests/info_snapshots.rs
+expression: json
+---
+{
+  "contexts": [],
+  "facets": {
+    "ci": {
+      "is_ci": false
+    }
+  },
+  "meta": {
+    "rules_version": "",
+    "schema_version": "0.1.0"
+  },
+  "traits": {
+    "color_level": "none",
+    "is_ci": false,
+    "is_interactive": false,
+    "is_piped_stdin": true,
+    "is_piped_stdout": true,
+    "is_tty_stderr": false,
+    "is_tty_stdin": false,
+    "is_tty_stdout": false,
+    "supports_hyperlinks": false
+  }
+}

--- a/tests/snapshots/info_snapshots__os_macos.snap
+++ b/tests/snapshots/info_snapshots__os_macos.snap
@@ -1,0 +1,27 @@
+---
+source: tests/info_snapshots.rs
+expression: json
+---
+{
+  "contexts": [],
+  "facets": {
+    "ci": {
+      "is_ci": false
+    }
+  },
+  "meta": {
+    "rules_version": "",
+    "schema_version": "0.1.0"
+  },
+  "traits": {
+    "color_level": "none",
+    "is_ci": false,
+    "is_interactive": false,
+    "is_piped_stdin": true,
+    "is_piped_stdout": true,
+    "is_tty_stderr": false,
+    "is_tty_stdin": false,
+    "is_tty_stdout": false,
+    "supports_hyperlinks": false
+  }
+}

--- a/tests/snapshots/info_snapshots__piped_io.snap
+++ b/tests/snapshots/info_snapshots__piped_io.snap
@@ -1,0 +1,27 @@
+---
+source: tests/info_snapshots.rs
+expression: json
+---
+{
+  "contexts": [],
+  "facets": {
+    "ci": {
+      "is_ci": false
+    }
+  },
+  "meta": {
+    "rules_version": "",
+    "schema_version": "0.1.0"
+  },
+  "traits": {
+    "color_level": "none",
+    "is_ci": false,
+    "is_interactive": false,
+    "is_piped_stdin": true,
+    "is_piped_stdout": true,
+    "is_tty_stderr": false,
+    "is_tty_stdin": false,
+    "is_tty_stdout": false,
+    "supports_hyperlinks": false
+  }
+}

--- a/tests/snapshots/info_snapshots__plain_tty.snap
+++ b/tests/snapshots/info_snapshots__plain_tty.snap
@@ -1,0 +1,27 @@
+---
+source: tests/info_snapshots.rs
+expression: json
+---
+{
+  "contexts": [],
+  "facets": {
+    "ci": {
+      "is_ci": false
+    }
+  },
+  "meta": {
+    "rules_version": "",
+    "schema_version": "0.1.0"
+  },
+  "traits": {
+    "color_level": "ansi256",
+    "is_ci": false,
+    "is_interactive": true,
+    "is_piped_stdin": false,
+    "is_piped_stdout": false,
+    "is_tty_stderr": true,
+    "is_tty_stdin": true,
+    "is_tty_stdout": true,
+    "supports_hyperlinks": false
+  }
+}

--- a/tests/snapshots/info_snapshots__shell_bash.snap
+++ b/tests/snapshots/info_snapshots__shell_bash.snap
@@ -1,0 +1,27 @@
+---
+source: tests/info_snapshots.rs
+expression: json
+---
+{
+  "contexts": [],
+  "facets": {
+    "ci": {
+      "is_ci": false
+    }
+  },
+  "meta": {
+    "rules_version": "",
+    "schema_version": "0.1.0"
+  },
+  "traits": {
+    "color_level": "none",
+    "is_ci": false,
+    "is_interactive": false,
+    "is_piped_stdin": true,
+    "is_piped_stdout": true,
+    "is_tty_stderr": false,
+    "is_tty_stdin": false,
+    "is_tty_stdout": false,
+    "supports_hyperlinks": false
+  }
+}

--- a/tests/snapshots/info_snapshots__shell_zsh.snap
+++ b/tests/snapshots/info_snapshots__shell_zsh.snap
@@ -1,0 +1,27 @@
+---
+source: tests/info_snapshots.rs
+expression: json
+---
+{
+  "contexts": [],
+  "facets": {
+    "ci": {
+      "is_ci": false
+    }
+  },
+  "meta": {
+    "rules_version": "",
+    "schema_version": "0.1.0"
+  },
+  "traits": {
+    "color_level": "none",
+    "is_ci": false,
+    "is_interactive": false,
+    "is_piped_stdin": true,
+    "is_piped_stdout": true,
+    "is_tty_stderr": false,
+    "is_tty_stdin": false,
+    "is_tty_stdout": false,
+    "supports_hyperlinks": false
+  }
+}

--- a/tests/snapshots/info_snapshots__tmux.snap
+++ b/tests/snapshots/info_snapshots__tmux.snap
@@ -1,0 +1,27 @@
+---
+source: tests/info_snapshots.rs
+expression: json
+---
+{
+  "contexts": [],
+  "facets": {
+    "ci": {
+      "is_ci": false
+    }
+  },
+  "meta": {
+    "rules_version": "",
+    "schema_version": "0.1.0"
+  },
+  "traits": {
+    "color_level": "ansi256",
+    "is_ci": false,
+    "is_interactive": true,
+    "is_piped_stdin": false,
+    "is_piped_stdout": false,
+    "is_tty_stderr": true,
+    "is_tty_stdin": true,
+    "is_tty_stdout": true,
+    "supports_hyperlinks": false
+  }
+}

--- a/tests/snapshots/info_snapshots__vscode.snap
+++ b/tests/snapshots/info_snapshots__vscode.snap
@@ -1,0 +1,30 @@
+---
+source: tests/info_snapshots.rs
+expression: json
+---
+{
+  "contexts": [
+    "ide"
+  ],
+  "facets": {
+    "ci": {
+      "is_ci": false
+    },
+    "ide_id": "vscode"
+  },
+  "meta": {
+    "rules_version": "",
+    "schema_version": "0.1.0"
+  },
+  "traits": {
+    "color_level": "none",
+    "is_ci": false,
+    "is_interactive": false,
+    "is_piped_stdin": true,
+    "is_piped_stdout": true,
+    "is_tty_stderr": false,
+    "is_tty_stdin": false,
+    "is_tty_stdout": false,
+    "supports_hyperlinks": false
+  }
+}

--- a/tests/snapshots/info_snapshots__vscode_insiders.snap
+++ b/tests/snapshots/info_snapshots__vscode_insiders.snap
@@ -1,0 +1,30 @@
+---
+source: tests/info_snapshots.rs
+expression: json
+---
+{
+  "contexts": [
+    "ide"
+  ],
+  "facets": {
+    "ci": {
+      "is_ci": false
+    },
+    "ide_id": "vscode-insiders"
+  },
+  "meta": {
+    "rules_version": "",
+    "schema_version": "0.1.0"
+  },
+  "traits": {
+    "color_level": "none",
+    "is_ci": false,
+    "is_interactive": false,
+    "is_piped_stdin": true,
+    "is_piped_stdout": true,
+    "is_tty_stderr": false,
+    "is_tty_stdin": false,
+    "is_tty_stdout": false,
+    "supports_hyperlinks": false
+  }
+}


### PR DESCRIPTION
## Summary
- add `insta` for JSON snapshot testing
- capture `envsense info --json` snapshots for IDEs, CI services, terminals, shells, and OS hints

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68a9add963788321a1c683417b0dc927