### PR TITLE
Add precommit hooks with lefthook for Rust formatting and linting

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,11 @@
+pre-commit:
+  commands:
+    format:
+      glob: "*.rs"
+      run: cargo fmt --all
+      stage_fixed: true
+      
+    clippy:
+      glob: "*.rs"
+      run: cargo clippy --all --locked --fix -D warnings --allow-dirty --allow-staged
+      stage_fixed: true

--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,3 @@
 [tools]
 rust = "1.89.0"
+"ubi:evilmartians/lefthook" = "latest"


### PR DESCRIPTION
- Configure cargo fmt with auto-staging for consistent code formatting
- Configure cargo clippy with auto-fixing and staging for code quality
- Maintain CI parity with same strictness (-D warnings)
- Manage lefthook via mise for consistent tooling

🤖 Generated with [Claude Code](https://claude.ai/code)