### PR TITLE
feat: add Homebrew formula for envsense installation

### DIFF
--- a/homebrew/envsense.rb
+++ b/homebrew/envsense.rb
@@ -1,0 +1,22 @@
+class Envsense < Formula
+  desc "Cross-language library and CLI for detecting the runtime environment"
+  homepage "https://github.com/technicalpickles/envsense"
+  head "https://github.com/technicalpickles/envsense.git", branch: "main"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args
+  end
+
+  test do
+    # Test that the binary exists and responds to --version
+    assert_match version.to_s, shell_output("#{bin}/envsense --version")
+    
+    # Test basic functionality - check that info command works
+    assert_match "contexts", shell_output("#{bin}/envsense info --json")
+    
+    # Test check command with a basic predicate
+    system bin/"envsense", "check", "--list"
+  end
+end


### PR DESCRIPTION
# Add Homebrew formula for envsense

I wanted to see if I could get this installed locally through Homebrew real quick. I can keep it in my own tap for now but thought I'd share!

## Summary

- Add Homebrew formula to enable installation via `brew install --HEAD`
- Formula builds from Git source using Cargo with proper Rust dependencies
- Includes basic tests to verify binary functionality

## Changes

- **homebrew/envsense.rb**: New Homebrew formula file
  - Builds from `main` branch using `head` directive
  - Depends on Rust for building
  - Uses standard Cargo installation pattern
  - Tests binary execution and basic commands

## Testing

The formula can be installed with:
```bash
HOMEBREW_DEVELOPER=1 brew install --HEAD ./homebrew/envsense.rb
```

Once installed, envsense is available system-wide:
```bash
envsense info
envsense check agent
```

## Future Work

- Create proper tap structure for easier installation
- Add version-based releases to enable non-HEAD installs
- Consider submitting to homebrew-core once stable
