### PR TITLE
Fix: Exclude test artifacts from GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,6 +98,16 @@ jobs:
       - name: Display downloaded files
         run: ls -la dist/
 
+      - name: Filter release files
+        shell: bash
+        run: |
+          echo "Filtering release files..."
+          mkdir -p release-files
+          # Copy only non-test files to release-files directory
+          find dist/ -name "envsense-v*" -not -name "*-test*" -exec cp {} release-files/ \;
+          echo "Release files:"
+          ls -la release-files/
+
       - name: Extract changelog
         shell: bash
         run: ./scripts/create-release.sh "${{ needs.check-version.outputs.new-version }}"
@@ -108,7 +118,7 @@ jobs:
           tag_name: ${{ needs.check-version.outputs.tag-name }}
           name: Release ${{ needs.check-version.outputs.tag-name }}
           body_path: changelog_excerpt.md
-          files: dist/*
+          files: release-files/*
           draft: false
           prerelease: false
           generate_release_notes: true


### PR DESCRIPTION
## Problem

The v0.2.0 release included unwanted test artifacts (files with \`-test\` in their names) alongside the legitimate release binaries. This happened because the release workflow was uploading all files from \`dist/*\`, which included both release files and test artifacts created by the test workflows.

## Solution

This PR modifies the release workflow to:

1. **Add a filtering step** that creates a separate \`release-files/\` directory
2. **Copy only non-test files** using: \`find dist/ -name "envsense-v*" -not -name "*-test*" -exec cp {} release-files/ \;\`
3. **Upload only filtered files** by changing \`files: dist/*\` to \`files: release-files/*\`

## Changes

- Modified \`.github/workflows/release.yml\` to filter out test artifacts before uploading to releases
- Added "Filter release files" step that excludes any files containing \`-test\`
- Updated the release upload to use the filtered files directory

## Testing

- Verified the filtering logic works correctly with existing files
- Cleaned up local test artifacts to ensure clean state
- The fix is backward compatible and doesn't break existing functionality

## Result

Future releases will only include:
- ✅ Actual release binaries (e.g., \`envsense-v0.2.0-universal-apple-darwin\`)
- ✅ Their corresponding checksums (e.g., \`envsense-v0.2.0-universal-apple-darwin.sha256\`)
- ❌ No more test artifacts (e.g., \`envsense-v0.1.0-test-*\`)

Resolves the issue identified in the v0.2.0 release.