### PR TITLE
Add Amp agent detection

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -97,6 +97,14 @@ fn descriptor(name: &str) -> (Option<&'static str>, Option<&'static str>, Vec<St
                 .map(String::from)
                 .collect(),
         ),
+        "amp" => (
+            Some("Amp"),
+            Some("terminal"),
+            vec!["code-edit", "run-commands", "file-ops"]
+                .into_iter()
+                .map(String::from)
+                .collect(),
+        ),
         "aider" => (
             Some("Aider"),
             Some("terminal"),

--- a/src/detectors/agent_declarative.rs
+++ b/src/detectors/agent_declarative.rs
@@ -134,6 +134,28 @@ mod tests {
     }
 
     #[test]
+    fn detects_amp_agent() {
+        let detector = DeclarativeAgentDetector::new();
+        let snapshot = create_env_snapshot(vec![("AGENT", "amp")]);
+
+        let detection = detector.detect(&snapshot);
+
+        assert!(detection.contexts_add.contains(&"agent".to_string()));
+
+        // Verify nested AgentTraits object
+        let agent_traits_value = detection.traits_patch.get("agent").unwrap();
+        let agent_traits: AgentTraits = serde_json::from_value(agent_traits_value.clone()).unwrap();
+        assert_eq!(agent_traits.id, Some("amp".to_string()));
+
+        // Verify legacy facet is maintained
+        assert_eq!(
+            detection.facets_patch.get("agent_id").unwrap(),
+            &json!("amp")
+        );
+        assert_eq!(detection.confidence, 1.0);
+    }
+
+    #[test]
     fn detects_replit_agent() {
         let detector = DeclarativeAgentDetector::new();
         let snapshot = create_env_snapshot(vec![("REPL_ID", "abc123")]);

--- a/src/detectors/env_mapping.rs
+++ b/src/detectors/env_mapping.rs
@@ -747,6 +747,22 @@ pub fn get_agent_mappings() -> Vec<EnvMapping> {
             contexts: vec!["agent".to_string()],
             value_mappings: vec![],
         },
+        // Amp detection
+        EnvMapping {
+            id: "amp".to_string(),
+            confidence: HIGH,
+            indicators: vec![EnvIndicator {
+                key: "AGENT".to_string(),
+                value: Some("amp".to_string()),
+                required: false,
+                prefix: false,
+                contains: None,
+                priority: 0,
+            }],
+            facets: HashMap::new(),
+            contexts: vec!["agent".to_string()],
+            value_mappings: vec![],
+        },
         // Cline detection
         EnvMapping {
             id: "cline".to_string(),
@@ -1376,6 +1392,17 @@ mod tests {
         let env_vars = HashMap::from([("AIDER_MODEL".to_string(), "gpt-4o-mini".to_string())]);
 
         assert!(aider_mapping.matches(&env_vars));
+    }
+
+    #[test]
+    fn test_amp_mapping() {
+        let mappings = get_agent_mappings();
+        let amp_mapping = mappings.iter().find(|m| m.id == "amp").unwrap();
+
+        let env_vars = HashMap::from([("AGENT".to_string(), "amp".to_string())]);
+
+        assert!(amp_mapping.matches(&env_vars));
+        assert_eq!(amp_mapping.confidence, HIGH);
     }
 
     #[test]

--- a/tests/cli_declarative.rs
+++ b/tests/cli_declarative.rs
@@ -90,6 +90,25 @@ fn cli_declarative_aider_detection() {
 }
 
 #[test]
+fn cli_declarative_amp_detection() {
+    let mut cmd = Command::cargo_bin("envsense").unwrap();
+    cmd.env_clear()
+        .env("AGENT", "amp")
+        .args(["check", "agent"])
+        .assert()
+        .success()
+        .stdout("true\n");
+
+    let mut cmd = Command::cargo_bin("envsense").unwrap();
+    cmd.env_clear()
+        .env("AGENT", "amp")
+        .args(["check", "agent.id=amp"])
+        .assert()
+        .success()
+        .stdout("true\n");
+}
+
+#[test]
 fn cli_declarative_openhands_detection() {
     let mut cmd = Command::cargo_bin("envsense").unwrap();
     cmd.env_clear()

--- a/tests/info_snapshots.rs
+++ b/tests/info_snapshots.rs
@@ -86,6 +86,12 @@ fn snapshot_cursor() {
 }
 
 #[test]
+fn snapshot_amp() {
+    let json = run_info_json(&[("AGENT", "amp")]);
+    assert_json_snapshot!("amp", json);
+}
+
+#[test]
 fn snapshot_github_actions() {
     let json = run_info_json(&[("GITHUB_ACTIONS", "1")]);
     assert_json_snapshot!("github_actions", json);

--- a/tests/snapshots/info_snapshots__amp.snap
+++ b/tests/snapshots/info_snapshots__amp.snap
@@ -1,0 +1,85 @@
+---
+source: tests/info_snapshots.rs
+expression: json
+---
+{
+  "contexts": [
+    "agent"
+  ],
+  "evidence": [
+    {
+      "confidence": 1.0,
+      "key": "terminal.stdin.tty",
+      "signal": "tty",
+      "supports": [
+        "terminal.stdin.tty"
+      ],
+      "value": "false"
+    },
+    {
+      "confidence": 1.0,
+      "key": "terminal.stdout.tty",
+      "signal": "tty",
+      "supports": [
+        "terminal.stdout.tty"
+      ],
+      "value": "false"
+    },
+    {
+      "confidence": 1.0,
+      "key": "terminal.stderr.tty",
+      "signal": "tty",
+      "supports": [
+        "terminal.stderr.tty"
+      ],
+      "value": "false"
+    },
+    {
+      "confidence": 1.0,
+      "key": "terminal.interactive",
+      "signal": "tty",
+      "supports": [
+        "terminal.interactive"
+      ],
+      "value": "false"
+    },
+    {
+      "confidence": 1.0,
+      "key": "AGENT",
+      "signal": "env",
+      "supports": [
+        "agent.id"
+      ],
+      "value": "amp"
+    }
+  ],
+  "facets": {},
+  "meta": {
+    "schema_version": "0.3.0"
+  },
+  "traits": {
+    "agent": {
+      "id": "amp"
+    },
+    "ci": {},
+    "ide": {},
+    "terminal": {
+      "color_level": "none",
+      "interactive": false,
+      "stderr": {
+        "piped": true,
+        "tty": false
+      },
+      "stdin": {
+        "piped": true,
+        "tty": false
+      },
+      "stdout": {
+        "piped": true,
+        "tty": false
+      },
+      "supports_hyperlinks": false
+    }
+  },
+  "version": "0.3.0"
+}


### PR DESCRIPTION
Adds support for detecting Amp running in agent mode via the \`AGENT=amp\` environment variable.

## Changes
- Add agent mapping in \`env_mapping.rs\` with HIGH confidence
- Add display name 'Amp' in \`agent.rs\` descriptor  
- Add comprehensive test coverage:
  - Unit test in \`agent_declarative.rs\`
  - CLI integration test in \`cli_declarative.rs\`
  - Mapping unit test in \`env_mapping.rs\`
  - Snapshot test in \`info_snapshots.rs\`

## Testing
All 329 tests passing ✅

## Example Usage
\`\`\`bash
AGENT=amp envsense info
# Contexts:
#   - agent
# Traits:
#   agent:
#     id: amp

AGENT=amp envsense check agent.id=amp
# true
\`\`\`